### PR TITLE
Fixed up syntax for rabbitmq_management section in rabbitmq.conf

### DIFF
--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -810,10 +810,11 @@ rabbitmq hard nofile 1234
           should contain_file('rabbitmq.config').with_content(%r{listener, \[})
           should contain_file('rabbitmq.config').with_content(%r{port, 5926\}})
           should contain_file('rabbitmq.config').with_content(%r{ssl, true\}})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[\{cacertfile, "/path/to/cacert"\},})
+          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
+          should contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
           should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
           should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
-          should contain_file('rabbitmq.config').with_content(%r{,\{versions, \['tlsv1.1', 'tlsv1.2'\]\}[\r\n ]*\]\}})
+          should contain_file('rabbitmq.config').with_content(%r{,\{versions, \['tlsv1.1', 'tlsv1.2'\]\}})
         end
       end
 
@@ -832,9 +833,10 @@ rabbitmq hard nofile 1234
           should contain_file('rabbitmq.config').with_content(%r{listener, \[})
           should contain_file('rabbitmq.config').with_content(%r{port, 3141\}})
           should contain_file('rabbitmq.config').with_content(%r{ssl, true\}})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[\{cacertfile, "/path/to/cacert"\},})
+          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
+          should contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
           should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}[\r\n ]*\]\}})
+          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
         end
       end
 
@@ -867,9 +869,10 @@ rabbitmq hard nofile 1234
           should contain_file('rabbitmq.config').with_content(%r{listener, \[})
           should contain_file('rabbitmq.config').with_content(%r{port, 3141\},})
           should contain_file('rabbitmq.config').with_content(%r{ssl, true\},})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[\{cacertfile, "/path/to/cacert"\},})
+          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
+          should contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
           should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}[\r\n ]*\]\}})
+          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
         end
       end
 

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -62,7 +62,9 @@
 <%- if @ssl -%>
       {port, <%= @ssl_management_port %>},
       {ssl, true},
-      {ssl_opts, [<%- if @ssl_cacert != 'UNSET' -%>{cacertfile, "<%= @ssl_cacert %>"},<%- end -%>
+      {ssl_opts, [<%- if @ssl_cacert != 'UNSET' %>
+                  {cacertfile, "<%= @ssl_cacert %>"},
+                  <%- end -%>
 
                   {certfile, "<%= @ssl_cert %>"},
                   {keyfile, "<%= @ssl_key %>"}


### PR DESCRIPTION
Fixed up how the template file generates the rabbitmq_mangement section
for rabbitmq.conf. Making its easier to read when you cat the generated
file on an agent, by correctly indenting and newlining configuration
parameters.

Also updated the rspec test to reflect the changes in the file contents.
